### PR TITLE
missing Gson parameter fix

### DIFF
--- a/app/src/main/java/co/joebirch/koindemo/data/DataRepositoryImpl.kt
+++ b/app/src/main/java/co/joebirch/koindemo/data/DataRepositoryImpl.kt
@@ -3,7 +3,7 @@ package co.joebirch.koindemo.data
 import co.joebirch.koindemo.model.Currency
 import com.google.gson.Gson
 
-open class DataRepositoryImpl(private val gson: Gson) {
+open class DataRepositoryImpl(private val gson: Gson = Gson()) {
 
     fun getCurrencies(jsonString: String): List<Currency> {
         return gson.fromJson(jsonString, Array<Currency>::class.java).toList()


### PR DESCRIPTION
factory { DataRepositoryImpl() } does not include a Gson parameter that you defined in the DataRepositoryImpl class. Simply adding a default constructor should solve the problem. Otherwise, you will get "No value passed for parameter 'gson' error in the Android Studio.
Later you can use get() in the DataRepositoryFactory, I think.